### PR TITLE
Matching XFCE version to VNC client for the Desktop app.

### DIFF
--- a/bc_ccv_desktop/form.yml
+++ b/bc_ccv_desktop/form.yml
@@ -33,7 +33,8 @@ attributes:
     value: "vnc"
   bc_num_slots: 1
   #x_module: "xfce/4.12"
-  x_module: "intltool/0.51.0 libwnck/3.24.1 xfce/4.16"
+  #x_module: "intltool/0.51.0 libwnck/3.24.1 xfce/4.16"
+  x_module: "intltool/0.51.0 libwnck/3.24.1 xfce/4.10"
   num_cores:
     value: 1
     widget: "number_field"

--- a/bc_ccv_desktop/template/desktops/xfce.sh
+++ b/bc_ccv_desktop/template/desktops/xfce.sh
@@ -13,8 +13,8 @@ fi
 PANEL_CONFIG="${XDG_CONFIG_HOME}/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml"
 if [[ ! -e "${PANEL_CONFIG}" ]]; then
   mkdir -p "$(dirname "${PANEL_CONFIG}")"
-  cp "/etc/xdg/xfce4/panel/default.xml" "${PANEL_CONFIG}"
-  #cp "/gpfs/runtime/opt/xfce/4.16/etc/xdg/xfce4/panel/default.xml" "${PANEL_CONFIG}"
+  #cp "/etc/xdg/xfce4/panel/default.xml" "${PANEL_CONFIG}"
+  cp "/gpfs/runtime/opt/xfce/4.10/etc/xdg/xfce4/panel/default.xml" "${PANEL_CONFIG}"
 fi
 
 # Disable startup services


### PR DESCRIPTION
This new branch uses XFCE 4.10 instead of 4.16. This makes the desktop app look exactly like the VNC client. 