### PR TITLE
virtualgl3 for vnc alt app

### DIFF
--- a/bc_ccv_vnc_alt/template/script.sh.erb
+++ b/bc_ccv_vnc_alt/template/script.sh.erb
@@ -11,7 +11,7 @@ cd "${HOME}"
 ##START ONLY for GPU Session
 if [[ <%= context.session%> == "gpu"* ]];
 then
-module load perl/5.24.1 ood_virtualgl/2.5.1
+module load perl/5.24.1 virtualgl/3.0.1 libjpeg-turbo/2.0.2
 fi
 ##END
 module load <%= context.x_module %>


### PR DESCRIPTION
The VNC Alternative app now uses virtualgl/3 . This is required for running the mne python package.