### PR TITLE
Adds Button to choose Jupyterlab in the Basic Jupyter Notebook app

### DIFF
--- a/bc_ccv_jupyter/form.yml
+++ b/bc_ccv_jupyter/form.yml
@@ -65,8 +65,15 @@ attributes:
     value: ""
     label: "Reservation"
     help: "Enter the reservation name here. Leave it blank if you are not using a reservation for submitting jobs."
+  mode:
+    widget: "radio"
+    value: "0"
+    options:
+      - ["Jupyter Lab","1"]
+      - ["Jupyter Notebook","0"]
 form:
   - anaconda_module
+  - mode
   - conda_env
   - modules
   #- jupyterlab_switch

--- a/bc_ccv_jupyter/template/script.sh.erb
+++ b/bc_ccv_jupyter/template/script.sh.erb
@@ -40,4 +40,4 @@ echo "TIMING - Starting jupyter at: $(date)"
 
 # Launch the Jupyter Notebook Server
 set -x
-jupyter-notebook --config="${CONFIG_FILE}" <%= context.extra_jupyter_args %>
+jupyter <%= context.mode == "1" ? "lab" : "notebook" %> --config="${CONFIG_FILE}" <%= context.extra_jupyter_args %>


### PR DESCRIPTION
This modifies the existing "Basic Jupyter Notebook" app and adds a radio button to choose Jupyter lab. The default option is Jupyter Notebook.This resolves issue #33 . Basic tests worked.