### PR TITLE
Mounted /lrs for RStudio.

### DIFF
--- a/bc_ccv_rstudio/template/script.sh.erb
+++ b/bc_ccv_rstudio/template/script.sh.erb
@@ -104,11 +104,11 @@ echo "*************************"
 <%- if context.r_module.include? "R/4" -%>
 
 SINGULARITYENV_LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/lib  SINGULARITYENV_PREPEND_PATH=$PATH singularity exec \
- --bind /gpfs/runtime,/gpfs/data,/gpfs/scratch,/gpfs/runtime/opt/ood_system/rstudio_server_sing/libs:/opt/lib,$tmp_path/run:/run,$tmp_path/var-lib-rstudio-server:/var/lib/rstudio-server,$tmp_path/database.conf:/etc/rstudio/database.conf,/gpfs/home/$USER:/users/$USER \
+ --bind /lrs,/gpfs/runtime,/gpfs/data,/gpfs/scratch,/gpfs/runtime/opt/ood_system/rstudio_server_sing/libs:/opt/lib,$tmp_path/run:/run,$tmp_path/var-lib-rstudio-server:/var/lib/rstudio-server,$tmp_path/database.conf:/etc/rstudio/database.conf,/gpfs/home/$USER:/users/$USER \
   /gpfs/runtime/opt/ood_system/rstudio_server_sing/rstudio_4.2.0.sif /bin/bash $tmp_path/rstudio_run_4.2.0.sh
 <%- else -%>
 SINGULARITYENV_LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/lib  SINGULARITYENV_PREPEND_PATH=$PATH singularity exec \
- --bind /gpfs/runtime,/gpfs/data,/gpfs/scratch,/gpfs/runtime/opt/ood_system/rstudio_server_sing/libs:/opt/lib,$tmp_path/run:/run,$tmp_path/var-lib-rstudio-server:/var/lib/rstudio-server,$tmp_path/database.conf:/etc/rstudio/database.conf,/gpfs/home/$USER:/users/$USER \
+ --bind /lrs,/gpfs/runtime,/gpfs/data,/gpfs/scratch,/gpfs/runtime/opt/ood_system/rstudio_server_sing/libs:/opt/lib,$tmp_path/run:/run,$tmp_path/var-lib-rstudio-server:/var/lib/rstudio-server,$tmp_path/database.conf:/etc/rstudio/database.conf,/gpfs/home/$USER:/users/$USER \
   /gpfs/runtime/opt/ood_system/rstudio_server_sing/rstudio_3.6.3.sif /bin/bash $tmp_path/rstudio_run_3.6.3.sh
 <%- end -%>
 


### PR DESCRIPTION
This PR mounts /lrs for the Rstudio Singularity image. This was requested in ticket 368846.
This PR can be tested by launching an RStudio job and running these commands.

```
getwd()
setwd("/lrs")
getwd()
```

The output should be "/lrs"