### PR TITLE
chore(vnc-cores): increase cores per GPU on dedicated VNC nodes

### DIFF
--- a/bc_ccv_vnc_alt/form.yml
+++ b/bc_ccv_vnc_alt/form.yml
@@ -20,8 +20,8 @@ attributes:
       - [ "4 Cores, 15GB Memory, 4 days", "cpu2" ]
       - [ "6 Cores, 20GB Memory, 3 days", "cpu3" ]
       - [ "8 Cores, 30GB Memory, 2 days", "cpu4" ]
-      - [ "2 Cores, 7GB Memory, 1 GPU, 4 days", "gpu1" ]
-      - [ "3 Cores, 15GB Memory, 2 GPUs, 2 days", "gpu2" ]
+      - [ "4 Cores, 7GB Memory, 1 GPU, 4 days", "gpu1" ]
+      - [ "6 Cores, 15GB Memory, 2 GPUs, 2 days", "gpu2" ]
   desktop: "xfce"
   # hardcoding XFCE as the environment 
   bc_vnc_idle: 0


### PR DESCRIPTION
Dedicated VNC GPU nodes now have 128 cores and 16 GPUs, which gives 8 cores per GPU. Keep the allocation conservative by assigning 4 cores per 1 GPU and 6 cores per 2 GPUs, leaving headroom for the OS, InfiniBand, and other system overhead.

This change is related to issues reported by Sarah Thomas (sthoma18). The previous config was chosen about a decade ago when the hardware was much more limited.